### PR TITLE
Update 76_style_guide.md

### DIFF
--- a/book/duckumentation/30_style_guide/76_style_guide.md
+++ b/book/duckumentation/30_style_guide/76_style_guide.md
@@ -12,6 +12,12 @@ The documentation is divided into books, parts (labeled 'part:') and units (with
 To create a new part, put `{#part:name status=STATUS}` after the header, like so:
 
     ## Safety {#part:safety status=ready}
+    
+For every page, please include a first-level header including a CSS-identifier and status in curly brackets. 
+Like this:
+    
+    `# Style guide {#documentation-style-guide status=ready}`
+    
 
 ## General guidelines for technical writing
 


### PR DESCRIPTION
I was told that a page without a first-level header does not get compiled. It might be the same for pages without status in the header line. 
Please only accept the change if this is true, and tell me if this is not true (I'll exclude such pages from knowledge graph creation as well).